### PR TITLE
Add the ability to execute files and use stdout

### DIFF
--- a/update_dotdee/__init__.py
+++ b/update_dotdee/__init__.py
@@ -82,7 +82,10 @@ class UpdateDotDee(PropertyManager):
         # created directory (see above).
         if all(map(self.context.is_file, (self.filename, self.checksum_file))):
             logger.info("Checking for local changes to %s ..", format_path(self.filename))
-            if self.hash_contents() != self.context.read_file(self.checksum_file):
+            # Decode to utf-8 string, otherwise false negatives will happen.
+            localhash = self.context.read_file(self.checksum_file).decode("utf-8")
+            logger.debug("Saved checksum is %s", localhash)
+            if self.hash_contents() != localhash:
                 if force:
                     logger.warning(compact(
                         """

--- a/update_dotdee/__init__.py
+++ b/update_dotdee/__init__.py
@@ -10,7 +10,6 @@
 import hashlib
 import logging
 import os
-import subprocess
 
 # External dependencies.
 from executor.contexts import LocalContext
@@ -173,7 +172,7 @@ class UpdateDotDee(PropertyManager):
         context.update(self.context.read_file(self.filename))
         hexdigest = context.hexdigest()
         logger.debug("SHA1 of %s is %s", format_path(self.filename), hexdigest)
-        return hexdigest.rstrip()
+        return hexdigest
 
 
 class RefuseToOverwrite(Exception):

--- a/update_dotdee/tests.py
+++ b/update_dotdee/tests.py
@@ -63,7 +63,7 @@ class UpdateDotDeeTestCase(TestCase):
                 # Check the order of the lines (natural order instead of lexicographical).
                 assert lines.index(first) < lines.index(middle)
                 assert lines.index(middle) < lines.index(last)
-    
+
     def test_executable(self):
         """Test that executable files are run, and non-executable ones aren't."""
         executable = "#!/bin/sh\necho I am echo output.\n"


### PR DESCRIPTION
Hi there. This PR contains both a bugfix and a feature addition.

For the bugfix, we prevent false negatives for detecting locally modified files by decoding the bytes from read_file to a utf-8 string. Without this, on my system, it would repeatedly complain that the resultant file was locally modified even if it wasn't, because the computed hash was a string, and the contents of read_file were bytes.

The feature addition is to execute files similar to the feature advertised by debian's dotdee package. If a file in the .d directory is executable, it runs that file and takes whatever was on stdout to add to the contents. The use case I implemented this for is downloading the current blocklist from someonewhocares.org any time I wanted to update /etc/hosts.