### PR TITLE
Allow disabling use of syslog logging

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,6 +144,26 @@ heavyweight solution. For the Python packages that I've published I wanted a
 more lightweight alternative that simply searches for and loads ``*.ini``
 configuration files. This is why ConfigLoader_ was added in release 5.0.
 
+Known issues
+------------
+
+By default, update-dotdee logs errors to both the terminal and
+to ``syslog``. The use of ``syslog`` logging from Python on Mac
+OS X may result in an exception being thrown::
+
+ --- Logging error ---
+ Traceback (most recent call last):
+   File
+   "/usr/local/Cellar/python@3.9/3.9.0_2/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/handlers.py",
+   line 953, in emit
+       self.socket.send(msg)
+       AttributeError: 'SysLogHandler' object has no attribute 'socket'
+
+You can disable ``syslog`` logging by exporting the environment
+variable ``UPDATE_DOTDEE_USE_SYSLOG`` with the value ``NO`` before
+running the program.
+
+
 Contact
 -------
 

--- a/update_dotdee/cli.py
+++ b/update_dotdee/cli.py
@@ -48,6 +48,7 @@ Supported options:
 # Standard library modules.
 import getopt
 import logging
+import os
 import sys
 
 # External dependencies.
@@ -64,8 +65,11 @@ logger = logging.getLogger(__name__)
 
 def main():
     """Command line interface for the ``update-dotdee`` program."""
-    # Initialize logging to the terminal and system log.
-    coloredlogs.install(syslog=True)
+    # Initialize logging to the terminal and (if not otherwise
+    # disabled) to the system log as well.
+    use_syslog = not os.getenv('UPDATE_DOTDEE_USE_SYSLOG',
+                               'True').upper() in ['NO', '0', 'FALSE']
+    coloredlogs.install(syslog=use_syslog)
     # Parse the command line arguments.
     context_opts = {}
     program_opts = {}


### PR DESCRIPTION
Because Mac OS X does not natively use `syslog`, there are situations where the Python `logging` module's `SysLogHandler` will throw an exception as follows:

```
$ update-dotdee ~/.ssh/config
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.0_2/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/handlers.py", line 953, in emit
    self.socket.send(msg)
AttributeError: 'SysLogHandler' object has no attribute 'socket'
Call stack:
  File "/Users/dittrich/.local/bin/update-dotdee", line 8, in <module>
    sys.exit(main())
  File "/Users/dittrich/.local/pipx/venvs/update-dotdee/lib/python3.9/site-packages/update_dotdee/cli.py", line 120, in main
    UpdateDotDee(**program_opts).update_file()
  File "/Users/dittrich/.local/pipx/venvs/update-dotdee/lib/python3.9/site-packages/update_dotdee/__init__.py", line 151, in update_file
    blocks.append(self.read_file(filename))
  File "/Users/dittrich/.local/pipx/venvs/update-dotdee/lib/python3.9/site-packages/update_dotdee/__init__.py", line 192, in read_file
    logger.info("Reading file: %s", format_path(filename))
Message: 'Reading file: %s'
Arguments: ('~/.ssh/config.d/00-header',)
2020-12-02 13:09:11 ren update_dotdee[9987] INFO Reading file: ~/.ssh/config.d/00-header
--- Logging error ---
Traceback (most recent call last):
  File "/usr/local/Cellar/python@3.9/3.9.0_2/Frameworks/Python.framework/Versions/3.9/lib/python3.9/logging/handlers.py", line 953, in emit
    self.socket.send(msg)
AttributeError: 'SysLogHandler' object has no attribute 'socket'
Call stack:
  File "/Users/dittrich/.local/bin/update-dotdee", line 8, in <module>
    sys.exit(main())
  File "/Users/dittrich/.local/pipx/venvs/update-dotdee/lib/python3.9/site-packages/update_dotdee/cli.py", line 120, in main
    UpdateDotDee(**program_opts).update_file()
  File "/Users/dittrich/.local/pipx/venvs/update-dotdee/lib/python3.9/site-packages/update_dotdee/__init__.py", line 151, in update_file
    blocks.append(self.read_file(filename))
  File "/Users/dittrich/.local/pipx/venvs/update-dotdee/lib/python3.9/site-packages/update_dotdee/__init__.py", line 192, in read_file
    logger.info("Reading file: %s", format_path(filename))
Message: 'Reading file: %s'
Arguments: ('~/.ssh/config.d/10-default',)
2020-12-02 13:09:11 ren update_dotdee[9987] INFO Reading file: ~/.ssh/config.d/10-default
--- Logging error ---
Traceback (most recent call last):
. . .
```

This happens with any version of Python. This may be due to having Homebrew `rsyslog` installed and configured in a manner that triggers a bug in the Python `logging` module. I have worked around this in the past by installing `update-dotdee` with `pipx` and manually patching the `handlers.py` file, but this quick "fix" is not ideal and reverts when the `logging` module gets updated and every time a new Python interpreter is installed (e.g., when doing `pipx reinstall-all`).

Because `update-dotdee` enables `syslog` logging by default, this results in errors that cannot be avoided.

This change allows the user to disable `syslog` logging by setting an environment variable to indicate their preference. The default behavior remains the same, so those who are not already experiencing these problems will see no change and won't have to do anything.